### PR TITLE
SUP-17749 Enforce minimum memory request

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -60,7 +60,8 @@ attributes:
   bc_num_memory:
     label: "Amount of RAM"
     widget: "text_field"
-    help: "Use Slurm format, e.g. 4096M, 10G. If left blank, 1000 MB will be allocated per CPU core requested."
+    pattern: "[0-9]+[MG]{1}"
+    help: "Use Slurm format, e.g. 4096M, 10G. If left blank, 1000 MB will be allocated per CPU core requested. A minimum of 2GB is required for each job and lower values will be substituted before submission."
 
   bc_num_gpus:
     label: "Number of GPUs"
@@ -71,6 +72,7 @@ attributes:
   bc_duration:
     label: "Duration of job"
     widget: "text_field"
+    value: "1:00:00"
     help: "Slurm format: DD-HH:MM:SS"
 
   working_dir:

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -2,6 +2,18 @@
 #
 # @note Used to define the submitted cluster, title, description, and
 #   hard-coded/user-defined attributes that make up this Batch Connect app.
+
+<%-
+  require 'open3'
+
+  def get_available_accounts()
+    cmd = "sacctmgr -nP show assoc format=account where user=#{CurrentUser.name}"
+    stdout, stderr, status = Open3.capture3(cmd)
+    accounts = stdout.split("\n")
+    accounts.delete("noalloc")
+    accounts
+  end
+%>
 ---
 
 # **MUST** set cluster id here that matches cluster configuration file located
@@ -28,9 +40,13 @@ attributes:
   
   bc_account:
     label: "Name of account"
-    widget: "text_field"
-    help: "Chargeable account of the form abcd-delta-cpu or abcd-delta-gpu. Replace abcd with your allocation code."
-    value: ""
+    widget: "select"
+    required: true
+    help: "Account selected must match job type (CPU or GPU)."
+    options:
+      <%- get_available_accounts().each do |account| %>
+      - ["<%= account %>", "<%= account %>"]
+      <%- end %>
   
   bc_reservation:
     label: "Name of reservation (leave empty if none)"
@@ -55,6 +71,7 @@ attributes:
   bc_num_slots:
     label: "Number of CPUs"
     widget: "number_field"
+    required: true
     min: "1"
 
   bc_num_memory:
@@ -72,6 +89,7 @@ attributes:
   bc_duration:
     label: "Duration of job"
     widget: "text_field"
+    required: true
     value: "1:00:00"
     help: "Slurm format: DD-HH:MM:SS"
 

--- a/info.html.erb
+++ b/info.html.erb
@@ -1,0 +1,22 @@
+<%- if ( user_context["bc_num_memory"].blank? and user_context["bc_num_slots"].to_i <= 2 ) or
+    ( not user_context["bc_num_memory"].blank? and
+      ( user_context["bc_num_memory"].end_with?('G') and user_context["bc_num_memory"][/[0-9]+/].to_i < 2 ) or
+      ( user_context["bc_num_memory"].end_with?('M') and user_context["bc_num_memory"][/[0-9]+/].to_i < 2048 )
+    ) %>
+
+<style>
+    .warning-box {
+        background-color: #fff3cd;
+        border: 1px solid #856404;
+        padding: 10px;
+        color: #856404;
+        border-radius: 5px;
+        font-size: 16px;
+    }
+</style>
+
+<div class="warning-box">
+    <strong>Warning:</strong> Memory requested is below minimum. Submitting job with 2GB of memory.
+</div>
+
+<%- end -%>

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -36,9 +36,19 @@ script:
   native:
     - "-N 1"
     - "-n"
-    - "<%= bc_num_slots.blank? ? 1 : bc_num_slots.to_i %>"
-    <%- unless bc_num_memory.blank? %>
+    - "<%= bc_num_slots.to_i %>"
+    <%- if bc_num_memory.blank? %>
+      <%- if bc_num_slots.to_i <= 2 %>
+    - "--mem=2G"
+      <%- end -%>
+    # do not explictly request memory if enough CPUs are requested
+    <%- else %>
+      <%- if ( bc_num_memory.end_with?('G') and bc_num_memory[/[0-9]+/].to_i < 2 ) or
+          ( bc_num_memory.end_with?('M') and bc_num_memory[/[0-9]+/].to_i < 2048 ) %>
+    - "--mem=2G"
+      <%- else %>
     - "--mem=<%= bc_num_memory %>"
+      <%- end -%>
     <%- end -%>
     - "-t"
     - "<%= bc_duration %>"


### PR DESCRIPTION
In response to reports of users requesting less memory than required by the apps, this change adds a mechanism to make sure the job starts with at least 2GB of memory, and notifies users with a visual warning when their request was automatically "fixed" by the system.

A second commit implements auto-detection of Slurm accounts available to the user. A range of accounts is now presented to the user instead of requiring them to manually enter the names, eliminating possible issues caused by typos.

Currently deployed on ood-test.