### PR TITLE
SVCPLAN-8480 Add RHEL 9 support for Jupyter app

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -52,6 +52,7 @@ attributes:
     label: "Name of reservation (leave empty if none)"
     widget: "text_field"
     value: ""
+    help: "The new RHEL 9 nodes are available via the RH9 reservation. To use the regular RHEL 8 nodes, leave this field empty."
 
   bc_partition:
     label: "Partition"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -11,16 +11,26 @@ echo "TIMING - Starting main script at: $(date)"
 hostname
 
 module purge
-module load default-s11
 
 module avail
 
 # Load the required modules
+if uname -r | grep -q "el9"; then
+  # RHEL 9 environment
+  module load default
 <%- if context.bc_partition.include? 'gpu' -%>
-module load anaconda3_gpu
+  module load pytorch-conda/2.8
 <%- else -%>
-module load anaconda3_cpu
+  module load miniforge3-python
 <%- end -%>
+else # RHEL 8 environment
+  module load default-s11
+<%- if context.bc_partition.include? 'gpu' -%>
+  module load anaconda3_gpu
+<%- else -%>
+  module load anaconda3_cpu
+<%- end -%>
+fi
 
 # List loaded modules
 module list


### PR DESCRIPTION
- support for RHEL 9 python modules
- a note to inform users that RHEL 9 nodes are available